### PR TITLE
Fix tuple order of get_memory_info()

### DIFF
--- a/src/rosprofiler/node_monitor.py
+++ b/src/rosprofiler/node_monitor.py
@@ -54,7 +54,7 @@ class NodeMonitor(object):
         """ Record cpu and memory information about this procress into a buffer """
         try:
             self.cpu_log.append(self._process.get_cpu_percent(interval=0))
-            virt, real = self._process.get_memory_info()
+            real, virt = self._process.get_memory_info()
             self.virt_log.append(virt)
             self.res_log.append(real)
             self.num_threads = max(self.num_threads, self._process.get_num_threads())


### PR DESCRIPTION
According to https://code.google.com/archive/p/psutil/wikis/Documentation.wiki
get_memory_info() returns a tuple representing RSS (Resident Set Size) and VMS (Virtual Memory Size) in bytes and not the other way around.